### PR TITLE
Add alt text for hero and parallax images

### DIFF
--- a/website/about.html
+++ b/website/about.html
@@ -9,6 +9,7 @@
 </head>
 <body>
     <header class="hero about-hero">
+        <img src="images/hero.jpg" alt="Hero background image" class="visually-hidden">
         <div class="hero-content">
             <h1>About Lamago</h1>
         </div>
@@ -22,7 +23,9 @@
         <h2>Our Story</h2>
         <p>Lamago was founded with a vision to deliver outstanding web experiences.</p>
     </section>
-    <section class="parallax"></section>
+    <section class="parallax">
+        <img src="images/parallax.jpg" alt="Parallax background image" class="visually-hidden">
+    </section>
     <section class="section">
         <h2>Meet the Team</h2>
         <p>Our diverse team brings creativity and technical excellence to every project.</p>

--- a/website/contact.html
+++ b/website/contact.html
@@ -9,6 +9,7 @@
 </head>
 <body>
     <header class="hero contact-hero">
+        <img src="images/hero.jpg" alt="Hero background image" class="visually-hidden">
         <div class="hero-content">
             <h1>Contact Us</h1>
         </div>

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -81,3 +81,15 @@ footer {
 .hidden {
     display: none;
 }
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/website/index.html
+++ b/website/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
     <header class="hero">
+        <img src="images/hero.jpg" alt="Hero background image" class="visually-hidden">
         <div class="hero-content">
             <h1>Welcome to Lamago</h1>
             <p>Your one stop solution for modern web experiences.</p>
@@ -24,7 +25,9 @@
         <h2>Our Services</h2>
         <p>We provide design, development and deployment services to bring your ideas to life.</p>
     </section>
-    <section class="parallax"></section>
+    <section class="parallax">
+        <img src="images/parallax.jpg" alt="Parallax background image" class="visually-hidden">
+    </section>
     <section class="section">
         <h2>Why Choose Us?</h2>
         <p>We craft responsive, high-performance websites using modern tools.</p>


### PR DESCRIPTION
## Summary
- add hidden `<img>` tags in hero and parallax sections to provide text alternatives
- add `.visually-hidden` helper class

## Testing
- `true`